### PR TITLE
Update CI runner

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         ghc: ['9.0', '9.4', '9.6']
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
                         
     name: ${{ matrix.os }} GHC ${{ matrix.ghc }}
     steps:


### PR DESCRIPTION
Ubuntu 20.04 deprecated, update to 22.04